### PR TITLE
feat: add dashboard template

### DIFF
--- a/src/molecules/avatar/avatar.stories.tsx
+++ b/src/molecules/avatar/avatar.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+
+import Avatar from './avatar';
+
+export default {
+  title: 'Molecules/Avatar',
+  component: Avatar,
+  argTypes: {},
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof Avatar>;
+
+const template: StoryFn<typeof Avatar> = (args) => <Avatar {...args} />;
+export const Default = template.bind({});
+Default.args = {
+  url: 'https://via.placeholder.com/150',
+  text: 'Avatar',
+};
+
+export const EmptyUrl = template.bind({});
+EmptyUrl.args = {
+  text: 'AV',
+};

--- a/src/molecules/avatar/avatar.tsx
+++ b/src/molecules/avatar/avatar.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+interface avatarProps {
+  text?: string;
+  url?: string;
+}
+
+export default function AvatarWrapper({ url, text }: avatarProps) {
+  return (
+    <Avatar>
+      <AvatarImage src={url} />
+      {text && <AvatarFallback>{text}</AvatarFallback>}
+    </Avatar>
+  );
+}

--- a/src/molecules/infocard/infocard.stories.tsx
+++ b/src/molecules/infocard/infocard.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+
+import InfoCard from './infocard';
+
+export default {
+  title: 'Molecules/info Card',
+  component: InfoCard,
+  argTypes: {},
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof InfoCard>;
+
+const Template: StoryFn<typeof InfoCard> = (args) => <InfoCard {...args} />;
+
+export const InfoCardStory = Template.bind({});
+
+InfoCardStory.args = {
+  title: 'People',
+  content: '15k',
+  description: 'Number of people in the system',
+  footer: 'Your target is 20K',
+};

--- a/src/molecules/infocard/infocard.tsx
+++ b/src/molecules/infocard/infocard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export type infoCardProps = {
+  content: string;
+  description: string;
+  footer: string;
+  title: string;
+};
+
+export default function InfoCard(infoCard: infoCardProps) {
+  return (
+    <Card>
+      <CardHeader className="text-base leading-7 text-gray-600">
+        <CardTitle>{infoCard.title}</CardTitle>
+        <CardDescription>{infoCard.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="order-first text-center text-3xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+        {infoCard.content}
+      </CardContent>
+      <CardFooter className="text-gray-400">
+        <p>{infoCard.footer}</p>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/organisms/cardList/CardList.stories.tsx
+++ b/src/organisms/cardList/CardList.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+
+import CardList from './CardList';
+
+export default {
+  title: 'Organism/Card list',
+  component: CardList,
+  argTypes: {},
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof CardList>;
+
+const Template: StoryFn<typeof CardList> = (args) => <CardList {...args} />;
+
+export const CardListStory = Template.bind({});
+
+CardListStory.args = {
+  cards: [
+    {
+      title: 'Paid',
+      content: '15%',
+      description: 'Number of paid taxes',
+      footer: 'Your target is 100%',
+    },
+    {
+      title: 'People',
+      content: '15k',
+      description: 'Number of people in the system',
+      footer: 'Your target is 20K',
+    },
+    {
+      title: 'WIP',
+      content: '1',
+      description: 'Number of WIP refunds',
+      footer: 'Your target is 0',
+    },
+  ],
+};

--- a/src/organisms/cardList/CardList.tsx
+++ b/src/organisms/cardList/CardList.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import InfoCard, { infoCardProps } from '../../molecules/infocard/infocard';
+
+export type CardListPorps = {
+  cards: Array<infoCardProps>;
+};
+
+export default function CardList(porps: CardListPorps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {porps.cards.map((card: infoCardProps) => (
+        <InfoCard key={card.title.replace(' ', '_')} {...card} />
+      ))}
+    </div>
+  );
+}

--- a/src/organisms/cardList/CardList.tsx
+++ b/src/organisms/cardList/CardList.tsx
@@ -8,7 +8,7 @@ export type CardListPorps = {
 
 export default function CardList(porps: CardListPorps) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {porps.cards.map((card: infoCardProps) => (
         <InfoCard key={card.title.replace(' ', '_')} {...card} />
       ))}

--- a/src/organisms/header/header.stories.tsx
+++ b/src/organisms/header/header.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+
+import DashboardHeader from './header';
+
+export default {
+  title: 'Organism/Header',
+  component: DashboardHeader,
+  argTypes: {},
+} as Meta<typeof DashboardHeader>;
+
+const Template: StoryFn<typeof DashboardHeader> = (args) => (
+  <DashboardHeader {...args} />
+);
+
+export const HeaderStory = Template.bind({});
+
+HeaderStory.args = {
+  heading: 'header',
+  text: 'test',
+};

--- a/src/organisms/header/header.tsx
+++ b/src/organisms/header/header.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import AvatarWrapper from '../../molecules/avatar/avatar';
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+} from '@/components/ui/navigation-menu';
+
+interface DashboardHeaderProps {
+  // heading: string
+  // text?: string
+  children?: React.ReactNode;
+}
+
+export default function DashboardHeader({ children }: DashboardHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-2 w-100">
+      <AvatarWrapper text="UR" url="" />
+      <span className="ml-2"> Unirefund </span>
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuLink>Settings</NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink>Tickets</NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink>Others</NavigationMenuLink>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
+      <div className="flex items-center gap-2">
+        <input type="text" placeholder="Search" className="rounded-md p-2" />
+        {children}
+      </div>
+      <AvatarWrapper text="AY" url="" />
+    </div>
+  );
+}

--- a/src/templates/dashboard/Dashboard.stories.tsx
+++ b/src/templates/dashboard/Dashboard.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+
+import Dashboard from './Dashboard';
+
+export default {
+  title: 'Template/Dashboard',
+  component: Dashboard,
+  argTypes: {},
+} as Meta<typeof Dashboard>;
+
+const Template: StoryFn<typeof Dashboard> = (args) => <Dashboard {...args} />;
+
+export const CardListStory = Template.bind({});

--- a/src/templates/dashboard/Dashboard.tsx
+++ b/src/templates/dashboard/Dashboard.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+import CardList from '../../organisms/cardList/CardList';
+import DashboardHeader from '../../organisms/header/header';
+
+export type DashboardProps = {
+  logo: string;
+  title: string;
+};
+
+const cards = {
+  cards: [
+    {
+      title: 'Paid',
+      content: '15%',
+      description: 'Number of paid taxes',
+      footer: 'Your target is 100%',
+    },
+    {
+      title: 'People',
+      content: '15k',
+      description: 'Number of people in the system',
+      footer: 'Your target is 20K',
+    },
+    {
+      title: 'WIP',
+      content: '1',
+      description: 'Number of WIP refunds',
+      footer: 'Your target is 0',
+    },
+    {
+      title: 'WIP',
+      content: '1',
+      description: 'Number of WIP refunds',
+      footer: 'Your target is 0',
+    },
+  ],
+};
+
+export default function Dashboard() {
+  // porps: DashboardProps
+  return (
+    <>
+      <DashboardHeader />
+      <div className="flex flex-col items-center justify-start h-screen w-11/12">
+        <div className="flex-row p-4">
+          <CardList {...cards} />
+        </div>
+        <div className="w-10/12 flex-row p-4 m-4">
+          <Table>
+            <TableCaption>A list of your recent invoices.</TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[100px]">Invoice</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Method</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell className="font-medium">INV001</TableCell>
+                <TableCell>Paid</TableCell>
+                <TableCell>Credit Card</TableCell>
+                <TableCell className="text-right">$250.00</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This PR adds the next to the UI:

- Molecules:
    - avatar: contains an avatar and fallback 
    ![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/3d58c898-f5ba-43b4-be71-5bbbbb08908d)
    - info cards: contains information to be shown in the dashboard
    ![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/450d4758-4c84-468d-8cf3-3ff5bb2e3558)
 
- Organisms:
    - card list: show a list of cards as grid 
![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/441c9b72-03a1-4a26-8159-808114b29b20)
    - header: contains logo, navigation bar and search 
![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/843bb8a3-5a70-4bd1-a076-b324b2882122)

- Templates
    - Dashboard: the template page and final look of the dashboard page
    ![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/5f285266-64e2-46cc-b23b-b3a783e69a1f)



## Todo
- continue working on the dasboard to extend the tables as organisms 
- implement the navigation for the header