### PR TITLE
Imports changed for shadcn

### DIFF
--- a/src/molecules/forms/login-form/index.tsx
+++ b/src/molecules/forms/login-form/index.tsx
@@ -1,16 +1,7 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
-import { ExclamationTriangleIcon, ReloadIcon } from '@radix-ui/react-icons';
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from '../../../../@/components/ui/alert';
-import { Button } from '../../../../@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   Form,
   FormControl,
@@ -18,8 +9,13 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from '../../../../@/components/ui/form';
-import { Input } from '../../../../@/components/ui/input';
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ExclamationTriangleIcon, ReloadIcon } from '@radix-ui/react-icons';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const formSchemaToTest = z.object({
   email: z.string().email(),

--- a/src/molecules/forms/register-form/index.tsx
+++ b/src/molecules/forms/register-form/index.tsx
@@ -3,15 +3,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ExclamationTriangleIcon, ReloadIcon } from '@radix-ui/react-icons';
 
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from '../../../../@/components/ui/alert';
-import { Button } from '../../../../@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   Form,
   FormControl,
@@ -19,8 +12,11 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from '../../../../@/components/ui/form';
-import { Input } from '../../../../@/components/ui/input';
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const formSchemaToTest = z.object({
   email: z.string().email(),

--- a/src/organisms/country-selector/index.tsx
+++ b/src/organisms/country-selector/index.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { Button } from '../../../@/components/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Command,
   CommandEmpty,
@@ -10,18 +10,18 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from '../../../@/components/ui/command';
+} from '@/components/ui/command';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from '../../../@/components/ui/popover';
+} from '@/components/ui/popover';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from '../../../@/components/ui/tooltip';
+} from '@/components/ui/tooltip';
 
 type CountrySelectItem = {
   label?: string;

--- a/src/organisms/novel/selectors/color-selector.tsx
+++ b/src/organisms/novel/selectors/color-selector.tsx
@@ -1,13 +1,13 @@
 import { Check, ChevronDown } from 'lucide-react';
 import { EditorBubbleItem, useEditor } from 'novel';
 
-import React from 'react';
-import { Button } from '../../../../@/components/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from '../../../../@/components/ui/popover';
+} from '@/components/ui/popover';
+import React from 'react';
 
 export interface BubbleColorMenuItem {
   color: string;

--- a/src/organisms/novel/selectors/link-selector.tsx
+++ b/src/organisms/novel/selectors/link-selector.tsx
@@ -1,10 +1,10 @@
+import { Button } from '@/components/ui/button';
+import { PopoverContent } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
 import { Popover, PopoverTrigger } from '@radix-ui/react-popover';
 import { Check, Trash } from 'lucide-react';
 import { useEditor } from 'novel';
 import React, { useEffect, useRef } from 'react';
-import { Button } from '../../../../@/components/ui/button';
-import { PopoverContent } from '../../../../@/components/ui/popover';
-import { cn } from '../../../../@/lib/utils';
 
 export function isValidUrl(url: string) {
   try {

--- a/src/organisms/novel/selectors/node-selector.tsx
+++ b/src/organisms/novel/selectors/node-selector.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/button';
+import { PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Popover } from '@radix-ui/react-popover';
 import {
   Check,
@@ -14,11 +16,6 @@ import {
 } from 'lucide-react';
 import { EditorBubbleItem, useEditor } from 'novel';
 import React from 'react';
-import { Button } from '../../../../@/components/ui/button';
-import {
-  PopoverContent,
-  PopoverTrigger,
-} from '../../../../@/components/ui/popover';
 
 export type SelectorItem = {
   command: (editor: ReturnType<typeof useEditor>['editor']) => void;

--- a/src/organisms/novel/selectors/text-buttons.tsx
+++ b/src/organisms/novel/selectors/text-buttons.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import {
   BoldIcon,
   CodeIcon,
@@ -7,8 +9,6 @@ import {
 } from 'lucide-react';
 import { EditorBubbleItem, useEditor } from 'novel';
 import React from 'react';
-import { Button } from '../../../../@/components/ui/button';
-import { cn } from '../../../../@/lib/utils';
 import type { SelectorItem } from './node-selector';
 
 export const TextButtons = () => {


### PR DESCRIPTION
- **feat(country-selector): tailwind direction support added**
- **feat(country-selector): tailwind direction support added**
- **refactor(export): exports and ile structures changed**
- **fix(novel): css import path changed**
- **Update country-selector.stories.tsx**
- **fix(country-selector): import changed**
- **feat(country-selector): tailwind direction support added (#17)**
- **fix(country-selector): rtl support**
- **feat(template): add main layout (#20)**
- **feat(two column layout): two column layout added**
- **refactor(login): login form & login page rewritten**
- **fix(login form): imports fixed**
- **feat(login form): extra props & external form schema**
- **feat(register form): register form & page**
- **fix(login & register stories): stories edited**
- **style(login form): spacing changed**
- **refactor(imports): imports for shadcn changed**
