### PR TITLE
fix: remove scroll when using the layout

### DIFF
--- a/src/molecules/side-bar/index.tsx
+++ b/src/molecules/side-bar/index.tsx
@@ -99,7 +99,7 @@ export default function SidebarMenu() {
   const uniqueLabels = Array.from(new Set(menus.map((menu) => menu.label)));
 
   return (
-    <ScrollArea className="h-screen lg:w-48 sm:w-full rounded-md">
+    <ScrollArea className="h-100 lg:w-48 sm:w-full rounded-md">
       <div className="md:px-4 sm:p-0 mt-5 ">
         {uniqueLabels.map((label, index) => (
           <React.Fragment key={label}>

--- a/src/templates/dashboard/index.tsx
+++ b/src/templates/dashboard/index.tsx
@@ -52,7 +52,7 @@ export default function Dashboard() {
   return (
     <>
       <DashboardHeader />
-      <div className="flex flex-col items-center justify-start h-screen w-11/12">
+      <div className="flex flex-col items-center justify-start h-100 w-11/12">
         <div className="flex-row p-4">
           <CardList {...cards} />
         </div>

--- a/src/templates/mainlayout/index.tsx
+++ b/src/templates/mainlayout/index.tsx
@@ -15,7 +15,7 @@ export default function Mainlayout({ logo, title, children }: mainLayoutProps) {
       <DashboardHeader />
       <div className="flex">
         <Sidebar />
-        <div className="flex-col w-full">
+        <div className="flex-col w-100 h-100">
           {`${logo} ${title}`}
           {children}
         </div>


### PR DESCRIPTION
This PR removes extra scroll from the screen when using the related components

Before: 

![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/1d98496f-d6d5-4da2-8a4a-742231ea537d)

After: 


![image](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-ui/assets/18273833/c3df3f3c-c228-4cea-8499-e631af45cf3a)
