### PR TITLE
feat: add two menus for the header to show language selector

### DIFF
--- a/src/molecules/sheet/sheet.stories.tsx
+++ b/src/molecules/sheet/sheet.stories.tsx
@@ -7,7 +7,7 @@ export default { component: Sheet } as Meta<typeof Sheet>;
 export const Default: StoryObj<typeof Sheet> = {
   args: {
     position: 'top',
-    triggerText: 'Open sheet',
+    trigger: 'Open sheet',
     title: 'Sheet title',
     description: 'Sheet description',
   },

--- a/src/organisms/header/index.tsx
+++ b/src/organisms/header/index.tsx
@@ -9,6 +9,7 @@ import BurgerMenu from '../burger-menu';
 
 interface DashboardHeaderProps {
   children?: React.ReactNode;
+  extraMenu?: React.ReactNode;
   logo?: string;
   navMenu: navigationLinkTypes[];
   title?: string;
@@ -21,6 +22,7 @@ export default function DashboardHeader({
   logo,
   userNav,
   navMenu,
+  extraMenu,
 }: DashboardHeaderProps) {
   return (
     <div className="flex items-center justify-between px-2 w-100">
@@ -28,7 +30,10 @@ export default function DashboardHeader({
       <AvatarWrapper text="UR" url={logo} sideText={title} />
       <Navigation className="hidden md:flex" navigationLinks={navMenu} />
       {children && <div className="flex items-center gap-2">{children}</div>}
-      <UserNav {...userNav} />
+      <div className="flex items-center gap-2">
+        {extraMenu && <div>{extraMenu}</div>}
+        <UserNav {...userNav} />
+      </div>
     </div>
   );
 }

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,7 +7,7 @@ import LoginForm, { LoginFormDataType } from '../../molecules/forms/login-form';
 import { CountrySelector } from '../../organisms/country-selector';
 import { TwoColumnLayout } from '../../templates/two-column-layout';
 
-const lang = {
+export const lang = {
   searchText: 'Find',
   searchEmptyValue: 'No country found.',
   defaultValue: {

--- a/src/templates/mainlayout/index.tsx
+++ b/src/templates/mainlayout/index.tsx
@@ -5,7 +5,8 @@ import Sidebar, { MenuProps } from '../../molecules/side-bar/index';
 import { navigationLinkTypes } from '../../molecules/navigation-menu';
 
 export type mainLayoutProps = {
-  children?: ReactElement<any, string | JSXElementConstructor<any>>;
+  children?: ReactElement<any, string | JSXElementConstructor<any>> | String;
+  extraMenu?: ReactElement | ReactElement;
   logo?: string;
   menus?: MenuProps[];
   navMenu: navigationLinkTypes[];
@@ -20,6 +21,7 @@ export default function Mainlayout({
   menus,
   userNav,
   navMenu,
+  extraMenu,
 }: mainLayoutProps) {
   // porps: DashboardProps
   return (
@@ -29,6 +31,7 @@ export default function Mainlayout({
         title={title}
         userNav={userNav}
         navMenu={navMenu}
+        extraMenu={extraMenu}
       />
       <div className="flex">
         <Sidebar className="hidden md:flex" menus={menus} />


### PR DESCRIPTION
This PR adds the ability to extend the header with two menus to use the language selector menu.