### PR TITLE
fix: take the fileds of table from another page

### DIFF
--- a/src/molecules/tables/index.tsx
+++ b/src/molecules/tables/index.tsx
@@ -94,6 +94,7 @@ export type columnsType = {
 };
 
 export type DataTableProps<TData> = {
+  Headertable?: any;
   action?: tableAction | tableAction[];
   columnsData: columnsType;
   data: TData[];
@@ -189,6 +190,7 @@ export default function DataTable<TData, TValue>({
   renderSubComponent,
   showView = true,
   editable = false,
+  Headertable,
 }: DataTableProps<TData>) {
   const [tableData, setTableData] = useState<TData[]>(data || []);
   const isMultipleActionProvided = Array.isArray(action);
@@ -282,7 +284,7 @@ export default function DataTable<TData, TValue>({
   }
 
   const handleAddRow = () => {
-    const newRow = {} as TData;
+    const newRow = Headertable;
     setTableData((prevData) => [...prevData, newRow]);
   };
 

--- a/src/molecules/tables/tables.stories.tsx
+++ b/src/molecules/tables/tables.stories.tsx
@@ -283,6 +283,7 @@ export const MultipleActions: StoryObj<typeof Table> = {
     layout: 'centered',
   },
 };
+const filedstable = { name: '', price: '' };
 export const Editable: StoryObj<typeof Table> = {
   args: {
     editable: true,
@@ -292,6 +293,7 @@ export const Editable: StoryObj<typeof Table> = {
       data: columnsEditable,
     },
     showView: false,
+    Headertable: filedstable,
   },
   parameters: {
     layout: 'centered',
@@ -300,7 +302,7 @@ export const Editable: StoryObj<typeof Table> = {
 
 export const SubContent: StoryObj<typeof Table> = {
   args: {
-    editable: true,
+    editable: false,
     data,
     columnsData: {
       type: 'Custom',


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
in this story there was an error when we use delete selected row button  so we use an variable to take the fileds of table from a nother page when we add a  new row

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
NO

### Testing Screenshots:

## Screenshots:

### Before:

### After:

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Added story.
- [x] Checked relative components.
- [x] Checked the component on production.
- [x] Added related docs.
