### PR TITLE
feat(AutoForm): readonly fields generator,fieldType generator, stickyChildren

### DIFF
--- a/src/organisms/auto-form/index.tsx
+++ b/src/organisms/auto-form/index.tsx
@@ -49,6 +49,8 @@ export type AutoFormProps = {
   onSubmit?: (values: z.infer<SchemaType>) => void;
   onValuesChange?: (values: ValueType) => void;
   showInRow?: boolean;
+  stickyChildren?: boolean;
+  stickyChildrenClassName?: string;
   values?: ValueType;
 };
 
@@ -65,6 +67,8 @@ function AutoForm({
   dependencies,
   showInRow,
   isLoading,
+  stickyChildren,
+  stickyChildrenClassName,
 }: AutoFormProps) {
   const objectFormSchema = getObjectFormSchema(formSchema);
   const defaultValues: DefaultValues<z.infer<typeof objectFormSchema>> | null =
@@ -116,7 +120,18 @@ function AutoForm({
           className={className}
         />
 
-        {children}
+        {stickyChildren ? (
+          <div
+            className={cn(
+              'sticky bottom-0 flex w-full items-center justify-end bg-white p-2 pr-0',
+              stickyChildrenClassName
+            )}
+          >
+            {children}
+          </div>
+        ) : (
+          children
+        )}
       </form>
     </Form>
   );

--- a/src/organisms/auto-form/utils.ts
+++ b/src/organisms/auto-form/utils.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { DefaultValues } from 'react-hook-form';
 import { z } from 'zod';
 import { FieldConfig } from './types';
+import { FieldConfigType } from '.';
 
 // TODO: This should support recursive ZodEffects but TypeScript doesn't allow circular type definitions.
 export type ZodObjectOrWrapped =
@@ -406,4 +407,60 @@ export function createValue(name: string, param: any, constantKey: string) {
     param[constantKey + temp[0]],
     constantKey
   );
+}
+
+export function createFieldTypeFieldConfig({
+  elements,
+  fieldType,
+}: {
+  elements: string[];
+  fieldType: string;
+}): FieldConfigType {
+  const fieldConfig = {};
+  for (const element of elements) {
+    Object.assign(fieldConfig, { [element]: { fieldType } });
+  }
+  return fieldConfig;
+}
+export function createReadonlyFieldConfig(elements: string[]): FieldConfigType {
+  const fieldConfig = {};
+  for (const element of elements) {
+    Object.assign(fieldConfig, {
+      [element]: { inputProps: { disabled: true } },
+    });
+  }
+  return fieldConfig;
+}
+/**
+ * Merges two FieldConfig objects recursively.
+ * @param source - The first FieldConfig object to merge.
+ * @param target - The second FieldConfig object to merge.
+ * @returns A new merged FieldConfig object.
+ */
+export function mergeFieldConfigs<
+  T extends FieldConfigType,
+  U extends FieldConfigType,
+>(source: T, target: U): T & U {
+  const targetKeys = Object.keys(target);
+  const sourceKeys = Object.keys(source);
+  const matchedKeys = sourceKeys.filter((key) => targetKeys.includes(key));
+  const uniqueKeys = sourceKeys.filter((key) => !targetKeys.includes(key));
+  const mergedObject = {};
+  for (const key of uniqueKeys) {
+    Object.assign(mergedObject, { [key]: source[key] });
+  }
+  const mergedMatchedObject = {};
+  for (const key of matchedKeys) {
+    Object.assign(mergedMatchedObject, {
+      [key]: {
+        ...source[key],
+        ...target[key],
+      },
+    });
+  }
+  const mergedResult: FieldConfigType = Object.assign(
+    mergedObject,
+    mergedMatchedObject
+  );
+  return mergedResult as T & U; // Return the merged result
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Testing Screenshots:

## Screenshots:
New features:
readonlyField: this function useful when multiple fields needs to be set disabled
![resim](https://github.com/user-attachments/assets/41518f5c-911c-4c75-abc4-d678524bdd49)
usage
![resim](https://github.com/user-attachments/assets/8287ced6-c033-47c1-96bd-cefb772594a6)

fieldTypeConfig: this function useful when multiple fields needs to be set same fieldType;
![resim](https://github.com/user-attachments/assets/9aa37b56-6a2f-434b-a30e-60c9857f57b6)
usage
![resim](https://github.com/user-attachments/assets/d50a6517-0297-4460-8889-cb5c1909ad67)

mergeFieldConfigs: this function merge 2 field config and merge them with respect each field, does not override any field(hopefully);
![resim](https://github.com/user-attachments/assets/b8f43318-40c8-443d-ab71-e323d6e1ff34)
usage
![resim](https://github.com/user-attachments/assets/89d69056-7d43-4657-9216-e405170bdc07)

stickyChildren: when this prop set true it wraps children element with sticky div, div classNames can be override with stickyChildrenClassName
![resim](https://github.com/user-attachments/assets/6c27ef7f-ac90-43b4-80a1-8f4c4b82d64f)

### Before:

### After:

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (non-breaking change which improve code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Added story.
- [ ] Checked relative components.
- [ ] Checked the component on production.
- [x] Added related docs.
