### PR TITLE
fix(custom-combobox): when selectIdentifier is number, as string can't cast it as string 

### DIFF
--- a/src/organisms/auto-form/fields/custom-combobox.tsx
+++ b/src/organisms/auto-form/fields/custom-combobox.tsx
@@ -160,7 +160,7 @@ function List<T>({
       filter={(commandValue, search) => {
         const filterResult = list?.find(
           (i) =>
-            (i[selectIdentifier] as string)?.toLocaleLowerCase() ===
+            i[selectIdentifier]?.toString()?.toLocaleLowerCase() ===
             commandValue.toLocaleLowerCase()
         )?.[selectLabel] as string;
         if (
@@ -180,8 +180,8 @@ function List<T>({
         <CommandGroup>
           {list?.map((item: T) => (
             <CommandItem
-              key={item[selectIdentifier] as string}
-              value={item[selectIdentifier] as string}
+              key={item[selectIdentifier]?.toString()}
+              value={item[selectIdentifier]?.toString()}
               onSelect={() => {
                 childrenProps.field.onChange(
                   item[selectIdentifier] === childrenProps.field.value


### PR DESCRIPTION
…t cast it as string

## Description

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Testing Screenshots:

## Screenshots:

### Before:

### After:

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (non-breaking change which improve code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Added story.
- [ ] Checked relative components.
- [ ] Checked the component on production.
- [ ] Added related docs.
